### PR TITLE
Support parse when start dates are in the past

### DIFF
--- a/lib/tickle/tickle.rb
+++ b/lib/tickle/tickle.rb
@@ -50,7 +50,7 @@ module Tickle
       # check to see if this event starts some other time and reset now
       scan_expression! tickled
 
-      fail(InvalidDateExpression, "the start date (#{@start.to_date}) cannot occur in the past for a future event") if @start && @start.to_date < Date.today
+      fail(InvalidDateExpression, "the start date (#{@start.to_date}) cannot occur in the past for a future event") if @start && @start.to_date < tickled.now.to_date
       fail(InvalidDateExpression, "the start date (#{@start.to_date}) cannot occur after the end date") if @until && @start.to_date > @until.to_date
 
       # no need to guess at expression if the start_date is in the future
@@ -75,7 +75,7 @@ module Tickle
 
         # if we can't guess it maybe chronic can
         _guess = guess(@tokens, @start)
-        best_guess = _guess || chronic_parse(tickled.event) # TODO fix this call 
+        best_guess = _guess || chronic_parse(tickled.event) # TODO fix this call
       end
 
       fail(InvalidDateExpression, "the next occurrence takes place after the end date specified") if @until && (best_guess.to_date > @until.to_date)
@@ -131,7 +131,7 @@ module Tickle
           fail(InvalidDateExpression,"the ending date expression \"#{tickled.ending}\" could not be interpretted")
         end
       else
-        @until = 
+        @until =
           if  tickled.starting && !tickled.starting.to_s.blank?
             if tickled.until && !tickled.until.to_s.blank?
               if tickled.until.to_time > @start

--- a/spec/tickle_spec.rb
+++ b/spec/tickle_spec.rb
@@ -241,6 +241,14 @@ describe "Parsing" do
         end
       end
 
+      context "Given that start is in the past, respect now option in parse" do
+        context "every other day" do
+          subject{ Tickle.parse('every other day', {:start=>Time.parse("2009-05-09 00:00:00 +0000"), :now=>Time.parse("2009-05-09 00:00:00 +0000"), :until=>Time.parse("2017-10-21 00:00:00 +0000") }) }
+          let(:expected) { {:next=>Time.parse("2009-05-11 00:00:00 +0000"), :expression=>"every other day", :starting=>Time.parse("2009-05-09 00:00:00 +0000"), :until=>nil} }
+          it { should == expected }
+        end
+      end
+
       context "Given that now is in the future, 2020-04-01 00:00:00 +0000" do
         context "February" do
           subject{ Tickle.parse('February', {:start=>Time.parse("2020-04-01 00:00:00 +0000"), :now=>Time.parse("2020-04-01 00:00:00 +0000")}) }


### PR DESCRIPTION
Prior to this change, Tickle would throw an error if the `start`
option passed in was in the past with respect to `Date.today`.
When attempting to enumerate intervals of dates that have already
occurred (in the case of looking backwards in a calendar), it is
important to be able to parse Tickle expressions and determine
what the next occurrence _was_ as opposed to when it _will be_.
While it appears that the parse API already supports a `:now` option,
it seems this option is ignored when checking this condition and,
instead, a `Date.today` is used.  This change simply uses the `:now`
as is passed to the `Tickled` object to validate `start_date`. Since
`Tickled#now` defaults to `Time.now`, this change is minimal but does
add value to the gem.

References: #4