### PR TITLE
Change the dependency from chronic to gitlab-chronic

### DIFF
--- a/lib/tickle.rb
+++ b/lib/tickle.rb
@@ -16,7 +16,7 @@ end
 
 require 'date'
 require 'time'
-require 'chronic'
+require 'gitlab-chronic'
 
 require 'tickle/tickle'
 require 'tickle/handler'

--- a/lib/tickle/tickled.rb
+++ b/lib/tickle/tickled.rb
@@ -1,10 +1,9 @@
-require 'chronic'
 require 'texttube/base'
 require_relative "filters.rb"
-require 'chronic'
+require 'gitlab-chronic'
 
 module Tickle
-      
+
 
 
   # Contains the initial input and the result of parsing it.
@@ -39,7 +38,7 @@ module Tickle
         end
       end
 
-      t = 
+      t =
         if asked.respond_to?(:to_time)
           asked
         elsif (t = Time.parse(asked) rescue nil) # a legitimate use!
@@ -129,7 +128,7 @@ module Tickle
 
     [:starting, :ending, :event].each do |meth|
       define_method meth do
-        @opts[meth] 
+        @opts[meth]
       end
       define_method "#{meth}=" do |value|
         @opts[meth] = Tickled.new value
@@ -157,13 +156,13 @@ module Tickle
     def to_s
       self
     end
-  
+
     def blank?
       if respond_to? :empty?
         empty? || !self
       elsif respond_to? :localtime
         false
-      end 
+      end
     end
 
 #     def inspect

--- a/tickle.gemspec
+++ b/tickle.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
-  
+
   s.require_paths = ["lib"]
 
   s.add_dependency "numerizer", "~> 0.2.0"
-  s.add_dependency "chronic",   "~> 0.10.2"
+  s.add_dependency "gitlab-chronic",   "~> 0.10.6"
   s.add_dependency "texttube",  "~> 6.0.0"
 end
 


### PR DESCRIPTION
As the regular chronic gem has a maintainer that isn't able to spend
time on it, Gitlab forked it and continued the maintenance.

Tickles test suite passes after moving to the gitlab-chronic gem and
with that development should be possible to continue without having to
wait on the missing features in regular chronic.